### PR TITLE
Update kikoplay.rb

### DIFF
--- a/Formula/kikoplay.rb
+++ b/Formula/kikoplay.rb
@@ -99,7 +99,7 @@ class Kikoplay < Formula
     libs = %W[
       -L#{Formula["lua@5.3"].lib}
       -L#{Formula["mpv"].lib}
-      -L#{Formula["protostars/kikoplay/qhttpengine"].lib}
+      -L#{Formula["kikoplayproject/kikoplay/qhttpengine"].lib}
     ]
     system "#{Formula["qt@5"].bin}/qmake",
            "LIBS += #{libs * " "}",


### PR DESCRIPTION
This can solve following error during installation:

```
Error: An exception occurred within a child process:
  TapFormulaUnavailableError: No available formula with the name "protostars/kikoplay/qhttpengine".
Please tap it and then try again: brew tap protostars/kikoplay
```